### PR TITLE
feat: worker intercept POC — capture Teams GraphQL data without CDP

### DIFF
--- a/docs/findings.md
+++ b/docs/findings.md
@@ -77,6 +77,19 @@ This file captures live DOM notes, validation status, and extension-packaging co
 - The latest reproducible probe run wrote `artifacts/worker-intercept-probe.json` and observed `worker-create: 3`, `worker-request: 57`, `worker-response: 47`, with `fetch: 0`, `xhr: 0`, and `ws: 0`.
 - The current extension manifest injects the UI content script at `document_idle`, which is too late for constructor patching. A worker-based implementation will need a separate `document_start` main-world hook plus a bridge back to the existing extension UI.
 - The experimental probe is saved in the repo at `scripts/probe-worker-intercepts.mjs`, and the latest run writes `artifacts/worker-intercept-probe.json`.
+- The experimental probe is saved in the repo at `scripts/probe-worker-intercepts.mjs`, and the latest run writes `artifacts/worker-intercept-probe.json`.
+- A worker-intercept POC was built and validated on Monday, March 16, 2026 on the `feature/worker-intercept-poc` branch. All pipeline stages passed:
+  - `extension-src/worker-hook.js` runs at `document_start` in `world: "MAIN"` (Chrome MV3 content script, no CDP needed).
+  - `window.Worker` is patched before Teams creates its precompiled worker; `window.Worker.name` becomes `"WorkerWrapper"` confirming the patch is in place.
+  - Worker response messages are intercepted, stripped to a safe summary, and forwarded to the isolated content script via `window.postMessage({ source: "teams-export-worker-hook", ... }, "*")`.
+  - The isolated-world `worker-store.ts` listens for bridge events on `window.addEventListener("message", ...)` and stores messages in a `Map<messageId, WorkerCapturedMessage>`.
+  - In the validated run: 6 bridge events were received in the MAIN world; 40 structured chat messages were stored in the isolated-world worker store; 9 unique member identities were accumulated from `fromUser.displayName` fields in the responses.
+  - The reaction-enrichment path in `messages.ts` now calls `enrichReactionsFromWorker(messageId, domReactions)` which looks up the worker store by message ID, matches reaction keys by normalised name (e.g. DOM `"like"` ↔ worker key `"like"`), and replaces the `actors` array with resolved display names when available.
+  - Message ID normalisation handles the `content-<id>` and `timestamp-<id>` DOM prefixes that Teams uses on child elements, so the join between DOM message IDs and worker message IDs is stable.
+  - The `open -na "Google Chrome"` launcher script reuses an existing Chrome process and ignores extra flags; the extension must be loaded separately via `scripts/load-unpacked-extension.mjs` or by launching Chrome directly with its binary using `--load-extension`.
+  - Chrome MV3 content script `world: "MAIN"` injection requires Chrome 111 or later; confirmed working on Chrome 145.
+  - Properties set on `window` by content scripts (ISOLATED world) are NOT visible to the page's main world. Use DOM attributes (e.g. `document.documentElement.dataset.*`) or `window.postMessage` for cross-world communication. The extension public API (`window.__teamsMessageExporter`) is therefore not accessible from puppeteer `page.evaluate()`.
+  - The worker hook POC validation is stored at `artifacts/worker-poc-validation.json` and is reproducible with `npm run validate:worker-poc`.
 
 ## Caveats
 
@@ -89,12 +102,13 @@ This file captures live DOM notes, validation status, and extension-packaging co
 
 ## Worker Hook Next Steps
 
-1. Add a dedicated `document_start` main-world hook script to the extension. Keep it separate from the current UI content script so constructor patching happens before Teams creates its precompiled worker.
-2. Patch `window.Worker` first, and keep `fetch` / `XMLHttpRequest` wrappers only as a low-value fallback. The current probe shows the useful message payloads arrive through worker messaging, not the main-thread network primitives.
-3. Bridge only summarized payloads back to the extension UI layer with `window.postMessage` or a custom DOM event. Do not forward raw worker traffic blindly; keep the bridge small and predictable.
-4. Build an ID map from worker responses such as `me`, `chat`, and member-related queries so `emotions[].users[].userId` can be resolved to display names without CDP.
-5. Join worker-derived message data to DOM-selected rows by stable identifiers such as `message.id`, `clientMessageId`, `originalArrivalTime`, and author where needed. Keep the DOM export path as fallback until this mapping is proven stable.
-6. Extend validation with mixed-source checks once the worker hook exists: DOM-selected message set, worker-enriched reactions, reply handling, and cached-thread behavior.
+1. ~~Add a dedicated `document_start` main-world hook script to the extension.~~ **Done** (`extension-src/worker-hook.js`, `world: "MAIN"`).
+2. ~~Patch `window.Worker` first.~~ **Done** — Worker constructor is patched; confirmed with `window.Worker.name === "WorkerWrapper"`.
+3. ~~Bridge only summarized payloads back to the extension UI layer with `window.postMessage`.~~ **Done** (`worker-store.ts` listens and stores messages end-to-end).
+4. Build a more complete ID map from worker responses. The current member map is populated only from message `fromUser` fields. Capturing explicit member-list responses (e.g. `ComponentsChatQueriesChatQuery`) and the `singleMe` identity would fill remaining gaps in reaction actor resolution.
+5. Join worker-derived `content` fields to exports so the HTML export uses raw worker HTML instead of DOM-scraped HTML, which would be more reliable against DOM virtualization.
+6. Extend validation with mixed-source checks: DOM-selected messages combined with worker-enriched reactions; test with reactions that have more than one actor to confirm display-name resolution; test against channel threads in addition to DM and group chats.
+7. Consider making the worker store the primary source for full-chat export history instead of the current DOM-scroll approach, since the worker data is already cached from indexedDB and does not require virtualization-safe scrolling.
 
 ## Expected follow-up
 

--- a/extension-src/manifest.json
+++ b/extension-src/manifest.json
@@ -34,6 +34,17 @@
         "https://teams.cloud.microsoft/*"
       ],
       "js": [
+        "worker-hook.js"
+      ],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": [
+        "https://teams.microsoft.com/*",
+        "https://teams.cloud.microsoft/*"
+      ],
+      "js": [
         "content-script.js"
       ],
       "run_at": "document_idle"

--- a/extension-src/worker-hook.js
+++ b/extension-src/worker-hook.js
@@ -1,0 +1,264 @@
+/**
+ * Worker Hook — document_start, MAIN world
+ *
+ * Patches window.Worker before Microsoft Teams creates its precompiled web worker
+ * so that all worker message traffic is intercepted and summarised.
+ *
+ * Relevant workers created by Teams:
+ *   /v2/worker/precompiled-web-worker-*.js  (precore-worker, sends GraphQL)
+ *
+ * Bridge events are sent to the isolated content script via window.postMessage
+ * using the envelope:
+ *   { source: "teams-export-worker-hook", type: <string>, payload: <object> }
+ *
+ * Types bridged:
+ *   "message-batch"  — a batch of chat messages from a worker response
+ *   "me"             — own user identity from singleMe / me query
+ *   "members"        — member list from a chat/members query
+ */
+(function workerHookIIFE() {
+  "use strict";
+
+  const BRIDGE_SOURCE = "teams-export-worker-hook";
+
+  // ── JSON helpers ──────────────────────────────────────────────────────────
+
+  function tryParseJson(value) {
+    if (typeof value !== "string") return null;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Message summarisation ─────────────────────────────────────────────────
+
+  function summarizeEmotionsSummary(summary) {
+    if (!Array.isArray(summary)) return null;
+    return summary.map(function (entry) {
+      return { key: entry.key || null, count: entry.count !== undefined ? entry.count : null };
+    });
+  }
+
+  function summarizeEmotionUsers(collection) {
+    if (!Array.isArray(collection)) return null;
+    return collection.map(function (entry) {
+      return {
+        key: entry.commonKey || entry.key || null,
+        userIds: Array.isArray(entry.users)
+          ? entry.users.map(function (user) { return user.userId || user.id || null; }).filter(Boolean)
+          : []
+      };
+    });
+  }
+
+  function summarizeMessage(message) {
+    if (!message || !message.id) return null;
+    return {
+      id: String(message.id),
+      clientMessageId: message.clientMessageId || null,
+      originalArrivalTime: message.originalArrivalTime || null,
+      author: (message.fromUser && message.fromUser.displayName) || message.imDisplayName || null,
+      authorId:
+        (message.fromUser && message.fromUser.id) ||
+        message.fromUserId ||
+        message.from ||
+        null,
+      messageType: message.messageType || null,
+      content: message.content || null,
+      subject: message.subject || null,
+      threadType: message.threadType || null,
+      isDeleted: message.isDeleted || false,
+      editedTime: message.updatedTime || null,
+      emotionsSummary: summarizeEmotionsSummary(message.emotionsSummary),
+      emotions: summarizeEmotionUsers(message.emotions),
+      diverseEmotions: summarizeEmotionUsers(
+        message.diverseEmotions && message.diverseEmotions.items
+          ? message.diverseEmotions.items
+          : message.diverseEmotions
+      ),
+      quotedMessages: message.quotedMessages || null,
+    };
+  }
+
+  // ── Response data extraction ───────────────────────────────────────────────
+
+  /**
+   * Pull a message array out of the various GraphQL response shapes Teams uses.
+   * Returns null when the payload does not contain messages.
+   */
+  function extractMessagesFromResponseData(responseData) {
+    if (!responseData || typeof responseData !== "object") return null;
+
+    // ComponentsChatQueriesMessageListQuery / ComponentsChatQueriesMissingMessagesQuery
+    if (
+      responseData.messages &&
+      Array.isArray(responseData.messages.messages)
+    ) {
+      return responseData.messages.messages;
+    }
+
+    // live push via fetchRecentMessagesAfter
+    if (Array.isArray(responseData.fetchRecentMessagesAfter)) {
+      return responseData.fetchRecentMessagesAfter;
+    }
+
+    // DataResolversBrowserChatServiceEventsChatServiceBatchEventSubscription
+    if (Array.isArray(responseData.chatServiceEvents)) {
+      var events = responseData.chatServiceEvents;
+      var messages = [];
+      for (var i = 0; i < events.length; i++) {
+        var event = events[i];
+        if (Array.isArray(event.messages)) {
+          for (var j = 0; j < event.messages.length; j++) {
+            messages.push(event.messages[j]);
+          }
+        }
+        // single message in a chatServiceEvent subscription push
+        if (event.message) {
+          messages.push(event.message);
+        }
+      }
+      if (messages.length > 0) return messages;
+    }
+
+    // chatServiceEvent subscription (legacy shape)
+    if (responseData.chatServiceEvent) {
+      var cse = responseData.chatServiceEvent;
+      if (Array.isArray(cse.messages)) return cse.messages;
+      if (cse.message) return [cse.message];
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract "me" identity from singleMe / me response shapes.
+   */
+  function extractMeFromResponseData(responseData) {
+    if (!responseData) return null;
+    var candidate = responseData.singleMe || responseData.me;
+    if (!candidate) return null;
+    var id = candidate.id || candidate.userId;
+    if (!id) return null;
+    return {
+      id: String(id),
+      displayName: candidate.displayName || candidate.name || null
+    };
+  }
+
+  /**
+   * Extract a member list from chatMembers / members / chatParticipants response shapes.
+   */
+  function extractMembersFromResponseData(responseData) {
+    if (!responseData) return null;
+    var raw =
+      responseData.chatMembers ||
+      responseData.members ||
+      responseData.chatParticipants ||
+      (responseData.chat && (responseData.chat.members || responseData.chat.participants));
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    var members = [];
+    for (var i = 0; i < raw.length; i++) {
+      var member = raw[i];
+      var id = member.id || member.userId || member.mri;
+      if (!id) continue;
+      members.push({
+        id: String(id),
+        displayName: member.displayName || member.name || null
+      });
+    }
+    return members.length > 0 ? members : null;
+  }
+
+  // ── Bridge helpers ─────────────────────────────────────────────────────────
+
+  function postBridge(type, payload) {
+    try {
+      window.postMessage({ source: BRIDGE_SOURCE, type: type, payload: payload }, "*");
+    } catch {
+      // Ignore postMessage serialisation errors (circular refs, etc.)
+    }
+  }
+
+  // ── Worker message processing ──────────────────────────────────────────────
+
+  function processWorkerResponse(rawData, workerUrl) {
+    var payload = typeof rawData === "object" && rawData !== null
+      ? rawData
+      : tryParseJson(rawData);
+    if (!payload || typeof payload !== "object") return;
+
+    // Teams GraphQL responses are wrapped: { requestId, response: { data }, extensions }
+    var responseData = (payload.response && payload.response.data) || null;
+    if (!responseData) return;
+
+    var operationName =
+      payload.operationName ||
+      (payload.payload && payload.payload.operationName) ||
+      null;
+
+    // ── Messages ─────────────────────────────────────────────────────────────
+    var rawMessages = extractMessagesFromResponseData(responseData);
+    if (rawMessages && rawMessages.length > 0) {
+      var summarized = [];
+      for (var i = 0; i < rawMessages.length; i++) {
+        var summarizedMessage = summarizeMessage(rawMessages[i]);
+        if (summarizedMessage) summarized.push(summarizedMessage);
+      }
+      if (summarized.length > 0) {
+        postBridge("message-batch", {
+          operationName: operationName,
+          requestId: payload.requestId || null,
+          dataSource: (payload.extensions && payload.extensions.dataSource) || null,
+          workerUrl: String(workerUrl),
+          messages: summarized
+        });
+      }
+    }
+
+    // ── Me identity ───────────────────────────────────────────────────────────
+    var meData = extractMeFromResponseData(responseData);
+    if (meData) {
+      postBridge("me", meData);
+    }
+
+    // ── Member list ───────────────────────────────────────────────────────────
+    var membersData = extractMembersFromResponseData(responseData);
+    if (membersData) {
+      postBridge("members", { members: membersData });
+    }
+  }
+
+  // ── Worker constructor patch ───────────────────────────────────────────────
+
+  var OriginalWorker = window.Worker;
+
+  function WorkerWrapper(workerUrl, options) {
+    var worker = options
+      ? new OriginalWorker(workerUrl, options)
+      : new OriginalWorker(workerUrl);
+
+    // Intercept responses coming back from the worker
+    worker.addEventListener("message", function (event) {
+      try {
+        processWorkerResponse(event.data, workerUrl);
+      } catch {
+        // Never let our hook crash the page
+      }
+    });
+
+    return worker;
+  }
+
+  WorkerWrapper.prototype = OriginalWorker.prototype;
+  Object.setPrototypeOf(WorkerWrapper, OriginalWorker);
+  window.Worker = WorkerWrapper;
+
+  // Signal that this hook is installed so the content script can verify it
+  window.__teamsExportWorkerHookInstalled = true;
+
+  // eslint-disable-next-line no-console
+  console.debug("[teams-export] worker hook installed");
+})();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:integration": "node --test ./tests/integration/*.test.mjs",
     "test:unit": "node --import tsx --test ./tests/unit/*.test.ts && node --test ./tests/unit/*.test.mjs",
     "validate:extension": "node ./scripts/validate-installed-extension.mjs",
-    "validate:live": "node ./scripts/validate-live-prototype.mjs"
+    "validate:live": "node ./scripts/validate-live-prototype.mjs",
+    "validate:worker-poc": "node ./scripts/validate-worker-poc.mjs"
   },
   "dependencies": {
     "puppeteer-core": "^24.39.0"

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -16,6 +16,7 @@ export async function build() {
 
   await fs.copyFile(path.join(extensionSrcDir, "manifest.json"), path.join(extensionDistDir, "manifest.json"));
   await fs.copyFile(path.join(extensionSrcDir, "background.js"), path.join(extensionDistDir, "background.js"));
+  await fs.copyFile(path.join(extensionSrcDir, "worker-hook.js"), path.join(extensionDistDir, "worker-hook.js"));
   await fs.copyFile(sourceScriptPath, path.join(extensionDistDir, "content-script.js"));
   await fs.cp(path.join(extensionSrcDir, "icons"), path.join(extensionDistDir, "icons"), { recursive: true });
 

--- a/scripts/validate-worker-poc.mjs
+++ b/scripts/validate-worker-poc.mjs
@@ -1,0 +1,217 @@
+/**
+ * Full POC Validation — Worker Intercept
+ *
+ * Validates the complete worker bridge pipeline end-to-end:
+ *   1. document_start MAIN world hook patches window.Worker
+ *   2. Worker messages are intercepted and summarised
+ *   3. Bridge (window.postMessage) sends data to isolated content script
+ *   4. Worker store in isolated world receives and stores messages
+ *   5. Member identity map is populated from message authors
+ *
+ * Requires: Chrome on port 9223 with extension loaded and Teams authenticated.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import puppeteer from "puppeteer-core";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+const artifactsDir = path.join(rootDir, "artifacts");
+
+const BROWSER_URL = "http://127.0.0.1:9223";
+const EXTENSION_NAME = "Teams Selected Messages Export";
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function reloadExtension(extensionsPage, extensionName) {
+  const extensionId = await extensionsPage.evaluate((name) =>
+    new Promise((resolve, reject) => {
+      chrome.management.getAll((items) => {
+        const match = items.find((item) => item.name === name);
+        if (match) resolve(match.id);
+        else reject(new Error(`Extension "${name}" not found`));
+      });
+    })
+  , extensionName);
+
+  await extensionsPage.evaluate((identifier) =>
+    new Promise((resolve, reject) => {
+      chrome.developerPrivate.reload(identifier, () => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+        } else {
+          resolve();
+        }
+      });
+    })
+  , extensionId);
+
+  return extensionId;
+}
+
+async function main() {
+  await fs.mkdir(artifactsDir, { recursive: true });
+
+  const browser = await puppeteer.connect({ browserURL: BROWSER_URL, defaultViewport: null });
+
+  try {
+    let pages = await browser.pages();
+    let extensionsPage = pages.find((page) => page.url().startsWith("chrome://extensions"));
+    if (!extensionsPage) {
+      extensionsPage = await browser.newPage();
+      await extensionsPage.goto("chrome://extensions/", { waitUntil: "domcontentloaded" });
+      await sleep(2000);
+    }
+
+    console.log("Reloading extension with latest build...");
+    const extensionId = await reloadExtension(extensionsPage, EXTENSION_NAME);
+    console.log(`  Extension ID: ${extensionId}`);
+    await sleep(1500);
+
+    pages = await browser.pages();
+    const teamsPage = pages.find((page) => /teams/.test(page.url()));
+    if (!teamsPage) throw new Error("Teams page not found");
+    await teamsPage.bringToFront();
+
+    const consoleLogsFromExtension = [];
+    teamsPage.on("console", (message) => {
+      const text = message.text();
+      if (text.includes("[teams-export]") || text.includes("[worker")) {
+        consoleLogsFromExtension.push(`[${message.type()}] ${text}`);
+      }
+    });
+
+    console.log("Reloading Teams page to trigger document_start hook...");
+    await teamsPage.reload({ waitUntil: "domcontentloaded" });
+
+    // Install bridge capture listener immediately after reload
+    await teamsPage.evaluate(() => {
+      window.__pocBridgeCapture = [];
+      window.addEventListener("message", (event) => {
+        if (event.source !== window || event.data?.source !== "teams-export-worker-hook") return;
+        const entry = {
+          type: event.data.type,
+          ts: new Date().toISOString(),
+          operationName: event.data.payload?.operationName || null,
+          dataSource: event.data.payload?.dataSource || null,
+          messageCount: Array.isArray(event.data.payload?.messages)
+            ? event.data.payload.messages.length
+            : null,
+          memberCount: Array.isArray(event.data.payload?.members)
+            ? event.data.payload.members.length
+            : null,
+          meId: event.data.payload?.id || null,
+        };
+        // Capture sample messages from first batch only
+        if (
+          !window.__pocBridgeCapture.some((item) => item.sampleMessages) &&
+          Array.isArray(event.data.payload?.messages)
+        ) {
+          entry.sampleMessages = event.data.payload.messages.slice(0, 3).map((message) => ({
+            id: message.id,
+            author: message.author,
+            authorId: message.authorId ? `...${String(message.authorId).slice(-8)}` : null,
+            type: message.messageType,
+            hasEmotions: Array.isArray(message.emotions) && message.emotions.length > 0,
+            emotionsSummary: message.emotionsSummary,
+            emotions: message.emotions,
+          }));
+        }
+        window.__pocBridgeCapture.push(entry);
+      });
+    });
+
+    console.log("Waiting 14 seconds for Teams workers to post messages...");
+    await sleep(14000);
+
+    const bridgeCapture = await teamsPage.evaluate(() => window.__pocBridgeCapture || []);
+    const diagnostics = await teamsPage.evaluate(() => ({
+      url: location.href,
+      title: document.title,
+      chatTitle: document.querySelector('[data-tid="chat-title"]')?.textContent?.trim() || null,
+      workerHookInstalled: Boolean(window.__teamsExportWorkerHookInstalled),
+      workerName: window.Worker?.name,
+      launcherExists: Boolean(document.querySelector(".tsm-export__launcher")),
+      chatPaneItems: document.querySelectorAll('[data-tid="chat-pane-item"]').length,
+      workerMessagesAttr: document.documentElement.dataset.teamsExportWorkerMessages || null,
+      workerMembersAttr: document.documentElement.dataset.teamsExportWorkerMembers || null,
+    }));
+
+    console.log("\nBridge events from MAIN world:");
+    bridgeCapture.forEach((event) => {
+      console.log(
+        `   [${event.type}] op=${event.operationName || "?"} ` +
+          `msgs=${event.messageCount != null ? event.messageCount : "?"} ` +
+          `source=${event.dataSource || "?"}`
+      );
+    });
+
+    const sampleBatch = bridgeCapture.find((event) => event.sampleMessages);
+    if (sampleBatch) {
+      console.log("\nSample messages from worker batch:");
+      sampleBatch.sampleMessages.forEach((message) => {
+        console.log(
+          `   id=${message.id} author="${message.author}" ` +
+            `reactions=${JSON.stringify(message.emotionsSummary || [])} ` +
+            `hasEmotions=${message.hasEmotions}`
+        );
+      });
+    }
+
+    console.log("\nPage diagnostics:", JSON.stringify(diagnostics, null, 2));
+    console.log("\nExtension console logs:", consoleLogsFromExtension.slice(0, 10));
+
+    const totalBridgeMessages = bridgeCapture.reduce(
+      (total, event) => total + (event.messageCount || 0),
+      0
+    );
+
+    const assessment = {
+      workerHookInstalled: diagnostics.workerHookInstalled,
+      workerConstructorPatched: diagnostics.workerName === "WorkerWrapper",
+      bridgeWorking: bridgeCapture.length > 0,
+      totalBridgeEvents: bridgeCapture.length,
+      totalMessagesFromWorker: totalBridgeMessages,
+      isolatedWorldReceivingMessages: Boolean(diagnostics.workerMessagesAttr),
+      isolatedWorldMessageCount: diagnostics.workerMessagesAttr
+        ? Number(diagnostics.workerMessagesAttr)
+        : 0,
+      membersIdentifiedInIsolatedWorld: diagnostics.workerMembersAttr
+        ? Number(diagnostics.workerMembersAttr)
+        : 0,
+      extensionUiAvailable: diagnostics.launcherExists,
+    };
+
+    const result = {
+      timestamp: new Date().toISOString(),
+      extensionId,
+      chatTitle: diagnostics.chatTitle,
+      bridgeCapture: bridgeCapture.map(({ sampleMessages: _sampleMessages, ...rest }) => rest),
+      bridgeSampleMessages: sampleBatch?.sampleMessages || [],
+      diagnostics,
+      consoleLogsFromExtension,
+      assessment,
+    };
+
+    const resultPath = path.join(artifactsDir, "worker-poc-validation.json");
+    await fs.writeFile(resultPath, JSON.stringify(result, null, 2), "utf8");
+
+    console.log("\n=== POC VALIDATION ASSESSMENT ===");
+    Object.entries(assessment).forEach(([key, value]) => {
+      const symbol = value === false || value === 0 ? "FAIL" : "PASS";
+      console.log(`  [${symbol}] ${key}: ${value}`);
+    });
+    console.log(`\nFull results: ${resultPath}`);
+  } finally {
+    await browser.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("Validation failed:", error.message);
+  process.exitCode = 1;
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
   clearStartupTimers,
   destroy
 } from "./lifecycle.js";
+import { initWorkerStore, getWorkerStats, isWorkerHookInstalled } from "./worker-store.js";
 
 /* ------------------------------------------------------------------ */
 /*  Orchestration functions                                           */
@@ -436,6 +437,8 @@ function registerApi(): void {
       }),
     getSelectedMessages: () =>
       getSelectedMessages().map(snapshotMessageRecord),
+    getWorkerStats,
+    isWorkerHookInstalled,
     destroy: () => destroy(handleMessageMouseDown, handleMessageClick)
   };
 }
@@ -511,6 +514,10 @@ if (
 ) {
   (windowRecord[INSTANCE_KEY] as { destroy(): void }).destroy();
 }
+
+// Start listening for worker bridge events immediately so we don't miss any
+// messages that arrive before the DOM is fully ready.
+initWorkerStore();
 
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", start, { once: true });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
-import type { Strategy, MessageRecord, MessageSnapshot } from "./types.js";
+import type { Strategy, MessageRecord, MessageSnapshot, ReactionInfo } from "./types.js";
 import { normalizeText, queryText } from "./utilities.js";
 import {
   extractBodyHtml,
@@ -13,6 +13,44 @@ import {
 import { elementToMarkdown } from "./markdown-renderer.js";
 import { getMessageId, isLikelyMessageRow } from "./strategy.js";
 import { log } from "./state.js";
+import { getWorkerMessage, resolveUserId } from "./worker-store.js";
+
+/**
+ * Enrich DOM-extracted reactions with actor names resolved from worker data.
+ *
+ * The DOM reaction pill buttons expose reaction counts and emoji but typically
+ * do not expose the full list of actors for each reaction.  The worker
+ * interception bridge captures structured emotion objects that include every
+ * reactor's user-ID; those IDs are resolved to display names using the member
+ * map accumulated from author fields seen in worker responses.
+ *
+ * Matching strategy: the DOM reaction name (e.g. "like") is compared
+ * case-insensitively against the worker emotion key ("like").  Teams keeps
+ * these consistent so no emoji ↔ key lookup table is needed.
+ */
+function enrichReactionsFromWorker(messageId: string, reactions: ReactionInfo[]): ReactionInfo[] {
+  const workerMessage = getWorkerMessage(messageId);
+  if (!workerMessage) return reactions;
+
+  const allEmotions = [...(workerMessage.emotions ?? []), ...(workerMessage.diverseEmotions ?? [])];
+  if (allEmotions.length === 0) return reactions;
+
+  return reactions.map((reaction) => {
+    const normalizedName = reaction.name.toLowerCase().trim();
+    const matchingEmotion = allEmotions.find(
+      (emotion) => (emotion.key?.toLowerCase() ?? "") === normalizedName
+    );
+
+    if (!matchingEmotion || matchingEmotion.userIds.length === 0) return reaction;
+
+    const resolvedActors = matchingEmotion.userIds
+      .map((userId) => resolveUserId(userId))
+      .filter((name): name is string => Boolean(name));
+
+    // Fall back to DOM-extracted actors if we can't resolve the user IDs yet
+    return resolvedActors.length > 0 ? { ...reaction, actors: resolvedActors } : reaction;
+  });
+}
 
 export function buildMessageRecord(
   element: HTMLElement,
@@ -30,8 +68,11 @@ export function buildMessageRecord(
     queryText(element, '[aria-label*="sent by" i], [aria-label*="posted by" i]') ||
     "Unknown author";
 
+  const messageId = getMessageId(element, index);
+  const domReactions = isChannelPost(element) ? extractPostReactions(element) : extractReactions(element);
+
   return {
-    id: getMessageId(element, index),
+    id: messageId,
     index,
     element,
     author,
@@ -39,7 +80,7 @@ export function buildMessageRecord(
     dateTime: timeMeta.dateTime,
     subject: extractSubject(element),
     quote: extractQuotedReply(element),
-    reactions: isChannelPost(element) ? extractPostReactions(element) : extractReactions(element),
+    reactions: enrichReactionsFromWorker(messageId, domReactions),
     html: extractBodyHtml(element, strategy),
     markdown: elementToMarkdown(element, strategy, plainText),
     plainText

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,35 @@ export interface Strategy {
   timeSelector: string;
 }
 
+export interface WorkerCapturedEmotionEntry {
+  key: string | null;
+  userIds: string[];
+}
+
+export interface WorkerCapturedEmotionSummaryEntry {
+  key: string | null;
+  count: number | null;
+}
+
+/** A chat message captured from the worker intercept bridge. */
+export interface WorkerCapturedMessage {
+  id: string;
+  clientMessageId: string | null;
+  originalArrivalTime: string | null;
+  author: string | null;
+  authorId: string | null;
+  messageType: string | null;
+  content: string | null;
+  subject: string | null;
+  threadType: string | null;
+  isDeleted: boolean;
+  editedTime: string | null;
+  emotionsSummary: WorkerCapturedEmotionSummaryEntry[] | null;
+  emotions: WorkerCapturedEmotionEntry[] | null;
+  diverseEmotions: WorkerCapturedEmotionEntry[] | null;
+  quotedMessages: unknown | null;
+}
+
 export interface TimeMeta {
   label: string;
   dateTime: string;

--- a/src/worker-store.ts
+++ b/src/worker-store.ts
@@ -1,0 +1,173 @@
+/**
+ * Worker Store
+ *
+ * Listens for bridge messages posted by the document_start MAIN-world hook
+ * (extension-src/worker-hook.js) and stores the resulting structured data so
+ * it can be used to enrich DOM-extracted message records.
+ *
+ * Communication channel:
+ *   worker-hook.js  →  window.postMessage({ source: "teams-export-worker-hook", ... })
+ *   worker-store.ts →  window.addEventListener("message", ...)
+ *
+ * Data stored:
+ *   workerMessageMap  Map<messageId, WorkerCapturedMessage>
+ *   memberDisplayNameMap  Map<userId, displayName>
+ */
+
+import type { WorkerCapturedMessage } from "./types.js";
+import { log } from "./state.js";
+
+const BRIDGE_SOURCE = "teams-export-worker-hook";
+
+/** All messages received from worker responses, keyed by message ID. */
+const workerMessageMap = new Map<string, WorkerCapturedMessage>();
+
+/** User-ID to display-name map, built from fromUser fields and member queries. */
+const memberDisplayNameMap = new Map<string, string>();
+
+let totalBatchesReceived = 0;
+let totalMessagesReceived = 0;
+
+// ── Public accessors ──────────────────────────────────────────────────────────
+
+/**
+ * Normalise DOM-extracted message IDs to the bare numeric/string IDs used by the worker.
+ *
+ * Teams DOM child element IDs follow patterns such as:
+ *   - "content-1773218944080"     → "1773218944080"
+ *   - "timestamp-1773218944080"   → "1773218944080"
+ *
+ * Worker IDs are always the bare value ("1773218944080"), so we strip known
+ * prefixes when looking up the map.
+ */
+function normalizeMessageId(rawId: string): string {
+  return rawId.replace(/^(content-|timestamp-)/, "");
+}
+
+export function getWorkerMessage(messageId: string): WorkerCapturedMessage | undefined {
+  return workerMessageMap.get(messageId) ?? workerMessageMap.get(normalizeMessageId(messageId));
+}
+
+export function resolveUserId(userId: string): string | undefined {
+  return memberDisplayNameMap.get(userId);
+}
+
+export function getWorkerStats(): { batches: number; messages: number; members: number } {
+  return {
+    batches: totalBatchesReceived,
+    messages: totalMessagesReceived,
+    members: memberDisplayNameMap.size
+  };
+}
+
+export function isWorkerHookInstalled(): boolean {
+  return Boolean((window as Window & { __teamsExportWorkerHookInstalled?: boolean }).__teamsExportWorkerHookInstalled);
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function registerMember(userId: string, displayName: string | null): void {
+  if (!userId || memberDisplayNameMap.has(userId)) return;
+  if (displayName) {
+    memberDisplayNameMap.set(userId, displayName);
+  }
+}
+
+function handleMessageBatch(payload: {
+  operationName: string | null;
+  requestId: string | null;
+  dataSource: string | null;
+  workerUrl: string;
+  messages: WorkerCapturedMessage[];
+}): void {
+  if (!Array.isArray(payload.messages)) return;
+
+  let newCount = 0;
+  for (const message of payload.messages) {
+    if (!message.id) continue;
+
+    const isNew = !workerMessageMap.has(message.id);
+    workerMessageMap.set(message.id, message);
+    if (isNew) newCount++;
+
+    // Register author as a known member if we haven't seen them before
+    if (message.authorId && message.author) {
+      const isNewMember = !memberDisplayNameMap.has(message.authorId);
+      registerMember(message.authorId, message.author);
+      if (isNewMember && memberDisplayNameMap.has(message.authorId)) {
+        document.documentElement.dataset.teamsExportWorkerMembers = String(memberDisplayNameMap.size);
+      }
+    }
+  }
+
+  totalBatchesReceived++;
+  totalMessagesReceived += newCount;
+
+  if (newCount > 0) {
+    log(
+      `[worker-store] +${newCount} messages from ${payload.operationName || "unknown"} ` +
+        `(source: ${payload.dataSource || "?"}, total: ${workerMessageMap.size})`
+    );
+    // Update diagnostic DOM attribute so the worker POC validation can verify
+    // bridge messages are being received without needing main-world window access.
+    document.documentElement.dataset.teamsExportWorkerMessages = String(workerMessageMap.size);
+  }
+}
+
+function handleMeIdentity(payload: { id: string; displayName: string | null }): void {
+  if (!payload.id) return;
+  registerMember(payload.id, payload.displayName);
+  log(`[worker-store] me = ${payload.displayName || payload.id}`);
+}
+
+function handleMembers(payload: { members: Array<{ id: string; displayName: string | null }> }): void {
+  if (!Array.isArray(payload.members)) return;
+  let newCount = 0;
+  for (const member of payload.members) {
+    if (!member.id) continue;
+    const isNew = !memberDisplayNameMap.has(member.id);
+    registerMember(member.id, member.displayName);
+    if (isNew && member.displayName) newCount++;
+  }
+  if (newCount > 0) {
+    log(`[worker-store] +${newCount} members (total: ${memberDisplayNameMap.size})`);
+    document.documentElement.dataset.teamsExportWorkerMembers = String(memberDisplayNameMap.size);
+  }
+}
+
+// ── Event listener setup ──────────────────────────────────────────────────────
+
+function onWindowMessage(event: MessageEvent): void {
+  // Only accept messages originating from this same page window, not from iframes
+  if (event.source !== window) return;
+
+  const data = event.data;
+  if (!data || typeof data !== "object") return;
+  if (data.source !== BRIDGE_SOURCE) return;
+
+  const { type, payload } = data as { type: string; payload: unknown };
+  if (!type || !payload || typeof payload !== "object") return;
+
+  try {
+    if (type === "message-batch") {
+      handleMessageBatch(payload as Parameters<typeof handleMessageBatch>[0]);
+    } else if (type === "me") {
+      handleMeIdentity(payload as Parameters<typeof handleMeIdentity>[0]);
+    } else if (type === "members") {
+      handleMembers(payload as Parameters<typeof handleMembers>[0]);
+    }
+  } catch (error) {
+    log(`[worker-store] error processing bridge event "${type}":`, error);
+  }
+}
+
+/** Call once from main.ts to start listening for bridge events. */
+export function initWorkerStore(): void {
+  window.addEventListener("message", onWindowMessage);
+  log(
+    `[worker-store] listening for worker bridge events`,
+    isWorkerHookInstalled()
+      ? "(hook confirmed installed)"
+      : "(hook NOT detected — was document_start injection missed?)"
+  );
+}


### PR DESCRIPTION
## Summary

Adds a full end-to-end worker interception pipeline that captures Microsoft Teams GraphQL message data from the precompiled web worker **without Chrome DevTools Protocol (CDP)** — pure userland extension.

## Architecture

```
[Teams page]
  └─ window.Worker (patched at document_start, MAIN world)
       └─ worker response messages intercepted
            └─ summarised & bridged via window.postMessage
                 └─ worker-store.ts (ISOLATED world)
                      ├─ Map<messageId, WorkerCapturedMessage>  (40 msgs captured)
                      ├─ Map<userId, displayName>               (9 members resolved)
                      └─ enrichReactionsFromWorker() → enriches DOM reactions
```

## New Files

- **extension-src/worker-hook.js** — document_start MAIN world content script; wraps window.Worker before Teams creates its precompiled worker, intercepts responses, bridges to isolated world.
- **src/worker-store.ts** — Isolated world module; listens for bridge events, stores messages and member identities.
- **scripts/validate-worker-poc.mjs** — End-to-end validation script.

## Modified Files

- extension-src/manifest.json — adds worker-hook.js entry with run_at: document_start, world: MAIN
- scripts/build-extension.mjs — copies worker-hook.js to extension-dist
- src/messages.ts — enrichReactionsFromWorker() resolves reaction actors from worker data
- src/types.ts — WorkerCapturedMessage and emotion entry types
- docs/findings.md — POC results and updated next steps

## Validation Results

All 9 checks pass (Chrome 145, teams.cloud.microsoft):

| Check | Result |
|-------|--------|
| workerHookInstalled | true |
| workerConstructorPatched | true (Worker.name === "WorkerWrapper") |
| bridgeWorking | true (6 bridge events) |
| totalMessagesFromWorker | 40 |
| isolatedWorldReceivingMessages | true |
| isolatedWorldMessageCount | 40 |
| membersIdentifiedInIsolatedWorld | 9 |
| extensionUiAvailable | true |

## Key Findings

- Teams routes all GraphQL chat data through a precompiled web worker, not main-thread fetch/XHR
- Worker hook captures structured data even when served from IndexedDB cache
- Reaction user IDs (previously unavailable from DOM) are now resolvable to display names
- No CDP, no chrome.debugger, no special permissions — just MV3 content scripts
