### PR TITLE
feat: Direct API POC - bypass Teams UI for message export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "teams-selected-messages-export",
       "dependencies": {
+        "playwright": "^1.58.2",
         "puppeteer-core": "^24.39.0"
       },
       "devDependencies": {
@@ -1142,6 +1143,50 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "validate:live": "node ./scripts/validate-live-prototype.mjs"
   },
   "dependencies": {
+    "playwright": "^1.58.2",
     "puppeteer-core": "^24.39.0"
   },
   "devDependencies": {

--- a/scripts/export-via-direct-api.mts
+++ b/scripts/export-via-direct-api.mts
@@ -21,6 +21,8 @@
  *   --list                   List conversations and exit
  *   --max-pages <n>          Max pagination pages (default: 100)
  *   --output <dir>           Output directory (default: artifacts/exports)
+ *   --auto                   Auto-acquire token (launches fresh Chrome, uses Intune passkey)
+ *   --email <email>           Corporate email for auto login (required with --auto)
  */
 
 import fs from "node:fs/promises";
@@ -28,6 +30,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import puppeteer from "puppeteer-core";
 
+import type { TeamsAuthToken } from "../src/direct-api-client.js";
 import {
   captureSkypeToken,
   findTeamsPage,
@@ -35,6 +38,7 @@ import {
   fetchAllMessages,
   fetchMembers,
 } from "../src/direct-api-client.js";
+import { acquireTokenAutomatically } from "../src/auto-token.js";
 import { convertApiMessagesToSnapshots } from "../src/direct-api-converter.js";
 import { renderMarkdown } from "../src/markdown-renderer.js";
 import { renderHtmlDocument } from "../src/html-renderer.js";
@@ -52,6 +56,8 @@ interface CliOptions {
   listOnly: boolean;
   maxPages: number;
   outputDirectory: string;
+  autoLogin: boolean;
+  email: string | null;
 }
 
 function parseArguments(): CliOptions {
@@ -62,6 +68,8 @@ function parseArguments(): CliOptions {
     listOnly: false,
     maxPages: 100,
     outputDirectory: defaultOutputDirectory,
+    autoLogin: false,
+    email: null,
   };
 
   for (let i = 0; i < arguments_.length; i++) {
@@ -81,6 +89,12 @@ function parseArguments(): CliOptions {
       case "--output":
         options.outputDirectory = arguments_[++i];
         break;
+      case "--auto":
+        options.autoLogin = true;
+        break;
+      case "--email":
+        options.email = arguments_[++i];
+        break;
     }
   }
 
@@ -99,8 +113,21 @@ function formatTimestamp(): string {
   return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 23);
 }
 
-async function main() {
-  const options = parseArguments();
+async function acquireToken(options: CliOptions): Promise<{ token: TeamsAuthToken; sourceUrl: string; disconnect: () => void }> {
+  if (options.autoLogin) {
+    if (!options.email) {
+      console.error("--email is required when using --auto");
+      process.exit(1);
+    }
+    console.log("Auto-acquiring token via Intune passkey...");
+    const token = await acquireTokenAutomatically({
+      email: options.email,
+      headless: true,
+      verbose: true,
+    });
+    console.log(`Token captured (${token.skypeToken.length} chars, region: ${token.region})`);
+    return { token, sourceUrl: "https://teams.cloud.microsoft/", disconnect: () => {} };
+  }
 
   console.log(`Connecting to Chrome at ${browserUrl}...`);
   const browser = await puppeteer.connect({ browserURL: browserUrl });
@@ -113,10 +140,16 @@ async function main() {
   }
   console.log(`Teams page: ${teamsPage.url()}`);
 
-  // Capture auth token
   console.log("Capturing auth token...");
   const token = await captureSkypeToken(teamsPage);
   console.log(`Token captured (${token.skypeToken.length} chars, region: ${token.region})`);
+  return { token, sourceUrl: teamsPage.url(), disconnect: () => browser.disconnect() };
+}
+
+async function main() {
+  const options = parseArguments();
+
+  const { token, sourceUrl, disconnect } = await acquireToken(options);
 
   // Fetch conversations
   console.log("\nFetching conversations...");
@@ -138,7 +171,7 @@ async function main() {
         `  [${i}] ${conversation.threadType}: "${conversation.topic}" (last: ${lastMessage})`,
       );
     }
-    browser.disconnect();
+    disconnect();
     return;
   }
 
@@ -155,7 +188,7 @@ async function main() {
       for (const conversation of displayableConversations.slice(0, 20)) {
         console.log(`  - "${conversation.topic}"`);
       }
-      browser.disconnect();
+      disconnect();
       process.exit(1);
     }
     targetConversation = match;
@@ -204,7 +237,7 @@ async function main() {
   const meta = {
     scope: "direct-api",
     title: targetConversation.topic,
-    sourceUrl: teamsPage.url(),
+    sourceUrl,
     exportedAt: new Date().toISOString(),
   };
 
@@ -225,7 +258,7 @@ async function main() {
   console.log(`  Messages: ${snapshots.length}`);
   console.log(`  Size: ${Math.round(content.length / 1024)} KB`);
 
-  browser.disconnect();
+  disconnect();
 }
 
 main().catch((error) => {

--- a/scripts/export-via-direct-api.mts
+++ b/scripts/export-via-direct-api.mts
@@ -1,0 +1,234 @@
+/**
+ * Export Teams Chat Messages via Direct API
+ *
+ * Connects to a running Chrome instance with Teams open, extracts
+ * auth tokens, fetches messages directly via the Teams REST API,
+ * and exports them as HTML or Markdown files.
+ *
+ * This bypasses the Teams UI entirely — no scrolling, no DOM scraping,
+ * no web worker interception. Just direct HTTP calls.
+ *
+ * Usage:
+ *   1. Start Chrome with remote debugging:
+ *        ./scripts/start-chrome-debug.sh
+ *   2. Navigate to Teams and log in
+ *   3. Run:
+ *        DEBUG_PORT=9223 npx -y tsx scripts/export-via-direct-api.mts [options]
+ *
+ * Options:
+ *   --format html|md         Export format (default: md)
+ *   --chat <name>            Partial match on conversation topic
+ *   --list                   List conversations and exit
+ *   --max-pages <n>          Max pagination pages (default: 100)
+ *   --output <dir>           Output directory (default: artifacts/exports)
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import puppeteer from "puppeteer-core";
+
+import {
+  captureSkypeToken,
+  findTeamsPage,
+  fetchConversations,
+  fetchAllMessages,
+  fetchMembers,
+} from "../src/direct-api-client.js";
+import { convertApiMessagesToSnapshots } from "../src/direct-api-converter.js";
+import { renderMarkdown } from "../src/markdown-renderer.js";
+import { renderHtmlDocument } from "../src/html-renderer.js";
+
+const currentFilename = fileURLToPath(import.meta.url);
+const currentDirectory = path.dirname(currentFilename);
+const rootDirectory = path.resolve(currentDirectory, "..");
+const defaultOutputDirectory = path.join(rootDirectory, "artifacts", "exports");
+
+const browserUrl = `http://127.0.0.1:${Number(process.env.DEBUG_PORT || "9222")}`;
+
+interface CliOptions {
+  format: "html" | "md";
+  chatFilter: string | null;
+  listOnly: boolean;
+  maxPages: number;
+  outputDirectory: string;
+}
+
+function parseArguments(): CliOptions {
+  const arguments_ = process.argv.slice(2);
+  const options: CliOptions = {
+    format: "md",
+    chatFilter: null,
+    listOnly: false,
+    maxPages: 100,
+    outputDirectory: defaultOutputDirectory,
+  };
+
+  for (let i = 0; i < arguments_.length; i++) {
+    switch (arguments_[i]) {
+      case "--format":
+        options.format = arguments_[++i] as "html" | "md";
+        break;
+      case "--chat":
+        options.chatFilter = arguments_[++i];
+        break;
+      case "--list":
+        options.listOnly = true;
+        break;
+      case "--max-pages":
+        options.maxPages = Number(arguments_[++i]);
+        break;
+      case "--output":
+        options.outputDirectory = arguments_[++i];
+        break;
+    }
+  }
+
+  return options;
+}
+
+function sanitizeFilename(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+}
+
+function formatTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 23);
+}
+
+async function main() {
+  const options = parseArguments();
+
+  console.log(`Connecting to Chrome at ${browserUrl}...`);
+  const browser = await puppeteer.connect({ browserURL: browserUrl });
+
+  const pages = await browser.pages();
+  const teamsPage = findTeamsPage(pages);
+  if (!teamsPage) {
+    console.error("No Teams page found. Navigate to Teams in the browser first.");
+    process.exit(1);
+  }
+  console.log(`Teams page: ${teamsPage.url()}`);
+
+  // Capture auth token
+  console.log("Capturing auth token...");
+  const token = await captureSkypeToken(teamsPage);
+  console.log(`Token captured (${token.skypeToken.length} chars, region: ${token.region})`);
+
+  // Fetch conversations
+  console.log("\nFetching conversations...");
+  const conversations = await fetchConversations(token, 50);
+
+  // Filter to chats with topics (exclude system streams)
+  const displayableConversations = conversations.filter(
+    (conversation) =>
+      conversation.topic &&
+      !["streamofannotations", "streamofthreads", "streamofnotifications", "streamofmentions", "streamofnotes"].includes(conversation.threadType),
+  );
+
+  if (options.listOnly) {
+    console.log(`\n${displayableConversations.length} conversations:\n`);
+    for (let i = 0; i < displayableConversations.length; i++) {
+      const conversation = displayableConversations[i];
+      const lastMessage = conversation.lastMessageTime?.slice(0, 10) ?? "unknown";
+      console.log(
+        `  [${i}] ${conversation.threadType}: "${conversation.topic}" (last: ${lastMessage})`,
+      );
+    }
+    browser.disconnect();
+    return;
+  }
+
+  // Find the target conversation
+  let targetConversation = displayableConversations[0];
+  if (options.chatFilter) {
+    const filter = options.chatFilter.toLowerCase();
+    const match = displayableConversations.find((conversation) =>
+      conversation.topic.toLowerCase().includes(filter),
+    );
+    if (!match) {
+      console.error(`No conversation matching "${options.chatFilter}" found.`);
+      console.log("Available conversations:");
+      for (const conversation of displayableConversations.slice(0, 20)) {
+        console.log(`  - "${conversation.topic}"`);
+      }
+      browser.disconnect();
+      process.exit(1);
+    }
+    targetConversation = match;
+  }
+
+  console.log(`\nExporting: "${targetConversation.topic}"`);
+  console.log(`  ID: ${targetConversation.id}`);
+  console.log(`  Type: ${targetConversation.threadType}`);
+
+  // Fetch members for reaction user resolution
+  console.log("\nFetching members...");
+  let members: Awaited<ReturnType<typeof fetchMembers>> = [];
+  try {
+    members = await fetchMembers(token, targetConversation.id);
+    console.log(`  ${members.length} members found`);
+  } catch (error) {
+    console.log(`  Members fetch failed: ${(error as Error).message}`);
+    members = [];
+  }
+
+  // Fetch all messages
+  console.log("\nFetching messages...");
+  const apiMessages = await fetchAllMessages(token, targetConversation.id, {
+    maxPages: options.maxPages,
+    pageSize: 200,
+    onProgress: (count) => {
+      process.stdout.write(`\r  ${count} messages fetched...`);
+    },
+  });
+  console.log(`\n  Total: ${apiMessages.length} messages`);
+
+  // Filter to text messages
+  const textMessages = apiMessages.filter(
+    (message) =>
+      (message.messageType === "RichText/Html" || message.messageType === "Text") &&
+      !message.isDeleted,
+  );
+  console.log(`  Text messages: ${textMessages.length}`);
+
+  // Convert to MessageSnapshot
+  console.log("\nConverting to export format...");
+  const snapshots = convertApiMessagesToSnapshots(apiMessages, members);
+  console.log(`  Snapshots: ${snapshots.length}`);
+
+  // Render
+  const meta = {
+    scope: "direct-api",
+    title: targetConversation.topic,
+    sourceUrl: teamsPage.url(),
+    exportedAt: new Date().toISOString(),
+  };
+
+  const content =
+    options.format === "html"
+      ? renderHtmlDocument(snapshots, meta)
+      : renderMarkdown(snapshots, meta);
+
+  // Write output
+  const filename = `${sanitizeFilename(targetConversation.topic)}-direct-api-${formatTimestamp()}.${options.format}`;
+  await fs.mkdir(options.outputDirectory, { recursive: true });
+  const outputPath = path.join(options.outputDirectory, filename);
+  await fs.writeFile(outputPath, content, "utf-8");
+
+  console.log(`\nExport complete:`);
+  console.log(`  File: ${outputPath}`);
+  console.log(`  Format: ${options.format}`);
+  console.log(`  Messages: ${snapshots.length}`);
+  console.log(`  Size: ${Math.round(content.length / 1024)} KB`);
+
+  browser.disconnect();
+}
+
+main().catch((error) => {
+  console.error("Fatal:", error);
+  process.exit(1);
+});

--- a/scripts/validate-direct-api.mts
+++ b/scripts/validate-direct-api.mts
@@ -1,0 +1,165 @@
+/**
+ * Validate Direct API POC
+ *
+ * Runs a quick end-to-end check that the direct API approach works:
+ *   1. Connects to Chrome, captures token
+ *   2. Lists conversations
+ *   3. Fetches messages from a conversation
+ *   4. Converts to snapshots
+ *   5. Renders markdown and HTML
+ *   6. Verifies output is non-empty
+ *
+ * Usage:
+ *   DEBUG_PORT=9223 npx -y tsx scripts/validate-direct-api.mts
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import puppeteer from "puppeteer-core";
+
+import {
+  captureSkypeToken,
+  findTeamsPage,
+  fetchConversations,
+  fetchMessages,
+  fetchMembers,
+} from "../src/direct-api-client.js";
+import { convertApiMessagesToSnapshots } from "../src/direct-api-converter.js";
+import { renderMarkdown } from "../src/markdown-renderer.js";
+import { renderHtmlDocument } from "../src/html-renderer.js";
+
+const currentFilename = fileURLToPath(import.meta.url);
+const currentDirectory = path.dirname(currentFilename);
+const rootDirectory = path.resolve(currentDirectory, "..");
+const artifactsDirectory = path.join(rootDirectory, "artifacts");
+
+const browserUrl = `http://127.0.0.1:${Number(process.env.DEBUG_PORT || "9222")}`;
+
+interface CheckResult {
+  name: string;
+  passed: boolean;
+  detail: string | number | boolean;
+}
+
+async function main() {
+  const checks: CheckResult[] = [];
+  let exitCode = 0;
+
+  function check(name: string, passed: boolean, detail: string | number | boolean) {
+    checks.push({ name, passed, detail });
+    const icon = passed ? "✅" : "❌";
+    console.log(`  ${icon} ${name}: ${detail}`);
+    if (!passed) exitCode = 1;
+  }
+
+  console.log(`Connecting to Chrome at ${browserUrl}...`);
+  const browser = await puppeteer.connect({ browserURL: browserUrl });
+
+  const pages = await browser.pages();
+  const teamsPage = findTeamsPage(pages);
+  check("teamsPageFound", !!teamsPage, !!teamsPage);
+  if (!teamsPage) {
+    browser.disconnect();
+    process.exit(1);
+  }
+
+  // 1. Capture token
+  console.log("\n=== Token Capture ===");
+  const token = await captureSkypeToken(teamsPage);
+  check("skypeTokenCaptured", !!token.skypeToken, token.skypeToken.length);
+  check("tokenRegionDetected", !!token.region, token.region);
+
+  // 2. Fetch conversations
+  console.log("\n=== Conversations ===");
+  const conversations = await fetchConversations(token, 10);
+  check("conversationsFetched", conversations.length > 0, conversations.length);
+
+  const firstChat = conversations.find(
+    (conversation) =>
+      conversation.topic &&
+      (conversation.threadType === "chat" || conversation.threadType === "topic"),
+  );
+  check("chatConversationFound", !!firstChat, firstChat?.topic ?? "none");
+
+  if (!firstChat) {
+    browser.disconnect();
+    process.exit(1);
+  }
+
+  // 3. Fetch messages
+  console.log("\n=== Messages ===");
+  const messagesPage = await fetchMessages(token, firstChat.id, 50);
+  check("messagesFetched", messagesPage.messages.length > 0, messagesPage.messages.length);
+
+  const textMessages = messagesPage.messages.filter(
+    (message) => message.messageType === "RichText/Html" || message.messageType === "Text",
+  );
+  check("textMessagesFound", textMessages.length > 0, textMessages.length);
+  check("paginationAvailable", !!messagesPage.backwardLink, !!messagesPage.backwardLink);
+
+  // 4. Fetch members
+  console.log("\n=== Members ===");
+  let members: Awaited<ReturnType<typeof fetchMembers>> = [];
+  try {
+    members = await fetchMembers(token, firstChat.id);
+    check("membersFetched", members.length > 0, members.length);
+  } catch {
+    check("membersFetched", false, "error");
+  }
+
+  // 5. Convert to snapshots
+  console.log("\n=== Conversion ===");
+  const snapshots = convertApiMessagesToSnapshots(messagesPage.messages, members);
+  check("snapshotsCreated", snapshots.length > 0, snapshots.length);
+
+  const reactionCount = snapshots.reduce(
+    (total, snapshot) => total + snapshot.reactions.length, 0
+  );
+  check("reactionsConverted", true, reactionCount);
+
+  const quoteCount = snapshots.filter((snapshot) => snapshot.quote !== null).length;
+  check("quotedRepliesDetected", true, quoteCount);
+
+  // 6. Render both formats
+  console.log("\n=== Rendering ===");
+  const meta = { scope: "direct-api", title: firstChat.topic, sourceUrl: teamsPage.url(), exportedAt: new Date().toISOString() };
+
+  const markdownOutput = renderMarkdown(snapshots, meta);
+  check("markdownRendered", markdownOutput.length > 100, `${markdownOutput.length} chars`);
+
+  const htmlOutput = renderHtmlDocument(snapshots, meta);
+  check("htmlRendered", htmlOutput.length > 100, `${htmlOutput.length} chars`);
+
+  // 7. Write validation output
+  const summary = {
+    timestamp: new Date().toISOString(),
+    checks,
+    allPassed: checks.every((result) => result.passed),
+    chatUsed: firstChat.topic,
+    conversationId: firstChat.id,
+    messageCount: textMessages.length,
+    snapshotCount: snapshots.length,
+    reactionCount,
+    quoteCount,
+    markdownSize: markdownOutput.length,
+    htmlSize: htmlOutput.length,
+  };
+
+  await fs.mkdir(artifactsDirectory, { recursive: true });
+  const summaryPath = path.join(artifactsDirectory, "direct-api-validation.json");
+  await fs.writeFile(summaryPath, JSON.stringify(summary, null, 2));
+
+  console.log(`\n${"=".repeat(50)}`);
+  console.log(`Validation: ${summary.allPassed ? "ALL PASSED ✅" : "SOME FAILED ❌"}`);
+  console.log(`  Checks: ${checks.filter((check) => check.passed).length}/${checks.length} passed`);
+  console.log(`  Results: ${summaryPath}`);
+
+  browser.disconnect();
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  console.error("Fatal:", error);
+  process.exit(1);
+});

--- a/src/auto-token.ts
+++ b/src/auto-token.ts
@@ -1,0 +1,210 @@
+/**
+ * Automated Teams Token Acquisition
+ *
+ * Launches a fresh Chrome instance, navigates to Teams, completes the
+ * Microsoft Entra ID login flow using the macOS Intune/Company Portal
+ * passkey provider, and captures the skype token via CDP Fetch interception.
+ *
+ * This enables fully automated token renewal with zero user interaction
+ * on machines that have Intune/Company Portal configured as a platform
+ * authenticator for FIDO2/WebAuthn.
+ *
+ * Requirements:
+ *   - macOS with Intune/Company Portal configured as a passkey provider
+ *   - System Chrome installed at /Applications/Google Chrome.app
+ *   - playwright package installed
+ *
+ * Usage:
+ *   import { acquireTokenAutomatically } from "./auto-token.js";
+ *   const token = await acquireTokenAutomatically("maxim.mazurok@wisetechglobal.com");
+ */
+
+import { chromium, type BrowserContext, type CDPSession } from "playwright";
+import type { TeamsAuthToken } from "./direct-api-client.js";
+
+const TEAMS_URL = "https://teams.cloud.microsoft/";
+const SYSTEM_CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const TEMP_PROFILE_DIRECTORY = "/tmp/teams-export-chrome-profile";
+const LOGIN_TIMEOUT = 60_000;
+const TOKEN_INTERCEPT_TIMEOUT = 30_000;
+
+export interface AutoTokenOptions {
+  /** Corporate email for Microsoft login */
+  email: string;
+  /** Path to Chrome executable (defaults to system Chrome on macOS) */
+  chromePath?: string;
+  /** Directory for temporary browser profile (cleaned on each run) */
+  profileDirectory?: string;
+  /** Run browser in headless mode (default: true) */
+  headless?: boolean;
+  /** Show progress messages (default: false) */
+  verbose?: boolean;
+}
+
+/**
+ * Acquire a Teams skype token fully automatically:
+ *   1. Launch system Chrome with a fresh profile
+ *   2. Navigate to Teams → redirects to Entra ID login
+ *   3. Enter email → org redirects to FIDO/passkey
+ *   4. macOS Intune completes passkey challenge silently
+ *   5. Teams loads → capture skype token from network requests
+ *   6. Close browser and return token
+ */
+export async function acquireTokenAutomatically(
+  options: AutoTokenOptions,
+): Promise<TeamsAuthToken> {
+  const chromePath = options.chromePath ?? SYSTEM_CHROME_PATH;
+  const profileDirectory = options.profileDirectory ?? TEMP_PROFILE_DIRECTORY;
+  const headless = options.headless ?? true;
+  const log = options.verbose ? console.log.bind(console) : () => {};
+
+  // Clean up any previous profile to ensure a fresh session
+  const { execSync } = await import("node:child_process");
+  execSync(`rm -rf "${profileDirectory}"`);
+
+  log("Launching Chrome with fresh profile...");
+  const context = await chromium.launchPersistentContext(profileDirectory, {
+    headless,
+    executablePath: chromePath,
+    args: [
+      "--disable-blink-features=AutomationControlled",
+      "--disable-features=VirtualAuthenticators",
+      "--enable-features=WebAuthenticationMacPlatform",
+      "--no-first-run",
+      "--no-default-browser-check",
+    ],
+    ignoreDefaultArgs: [
+      "--disable-component-extensions-with-background-pages",
+    ],
+  });
+
+  try {
+    const token = await performLoginAndCaptureToken(context, options.email, log);
+    return token;
+  } finally {
+    await context.close();
+    // Clean up profile directory
+    try {
+      execSync(`rm -rf "${profileDirectory}"`);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}
+
+async function performLoginAndCaptureToken(
+  context: BrowserContext,
+  email: string,
+  log: (...arguments_: unknown[]) => void,
+): Promise<TeamsAuthToken> {
+  const page = context.pages()[0] || await context.newPage();
+
+  // Navigate to Teams → triggers redirect to Entra ID login
+  log("Navigating to Teams...");
+  await page.goto(TEAMS_URL, { waitUntil: "domcontentloaded", timeout: LOGIN_TIMEOUT });
+
+  // Wait for the login page
+  await page.waitForURL(/login\.microsoftonline\.com|login\.microsoft\.com/, {
+    timeout: LOGIN_TIMEOUT,
+  }).catch(() => {
+    // May already be at Teams if session cached
+  });
+
+  // If we're at the login page, enter email
+  if (page.url().includes("login.microsoftonline.com") || page.url().includes("login.microsoft.com")) {
+    log("At login page, entering email...");
+
+    const emailInput = await page.waitForSelector(
+      '#i0116, input[name="loginfmt"], input[type="email"]',
+      { timeout: 15_000 },
+    ).catch(() => null);
+
+    if (emailInput) {
+      await emailInput.fill(email);
+
+      const nextButton = await page.waitForSelector("#idSIButton9", { timeout: 5_000 }).catch(() => null);
+      if (nextButton) {
+        log("Submitting email...");
+        await nextButton.click();
+      }
+    }
+
+    // Wait for FIDO/passkey flow to complete and redirect back to Teams
+    log("Waiting for passkey authentication...");
+    await page.waitForURL(/teams\.cloud\.microsoft/, {
+      timeout: LOGIN_TIMEOUT,
+      waitUntil: "domcontentloaded",
+    });
+  }
+
+  log(`Logged in. URL: ${page.url()}`);
+
+  // Now capture the skype token by intercepting network requests via CDP
+  log("Capturing skype token...");
+  const token = await captureTokenViaCdp(page, log);
+
+  return token;
+}
+
+async function captureTokenViaCdp(
+  page: Awaited<ReturnType<BrowserContext["newPage"]>>,
+  log: (...arguments_: unknown[]) => void,
+): Promise<TeamsAuthToken> {
+  const cdpSession: CDPSession = await page.context().newCDPSession(page);
+  let skypeToken: string | null = null;
+
+  await cdpSession.send("Fetch.enable", {
+    patterns: [{ urlPattern: "*teams*", requestStage: "Request" }],
+  });
+
+  const tokenPromise = new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, TOKEN_INTERCEPT_TIMEOUT);
+
+    cdpSession.on("Fetch.requestPaused", async (event: Record<string, unknown>) => {
+      const request = event.request as { headers?: Record<string, string> };
+      const requestId = event.requestId as string;
+
+      for (const [name, value] of Object.entries(request.headers ?? {})) {
+        if (name.toLowerCase() === "x-skypetoken" && !skypeToken) {
+          skypeToken = value;
+        }
+      }
+
+      try {
+        await cdpSession.send("Fetch.continueRequest", { requestId });
+      } catch {
+        // Request may have already been handled
+      }
+
+      if (skypeToken) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+  });
+
+  // Reload the page to trigger authenticated API requests
+  log("Reloading page to intercept token...");
+  page.reload({ waitUntil: "domcontentloaded", timeout: LOGIN_TIMEOUT }).catch(() => {
+    // Reload may time out, but token should be captured by then
+  });
+
+  await tokenPromise;
+
+  await cdpSession.send("Fetch.disable");
+  await cdpSession.detach();
+
+  if (!skypeToken) {
+    throw new Error(
+      "Failed to capture skype token after login. Teams may not have fully loaded.",
+    );
+  }
+
+  const capturedToken: string = skypeToken;
+  log(`Token captured (${capturedToken.length} chars)`);
+
+  return {
+    skypeToken: capturedToken,
+    region: "apac",
+  };
+}

--- a/src/direct-api-client.ts
+++ b/src/direct-api-client.ts
@@ -1,0 +1,374 @@
+/**
+ * Direct Teams API Client
+ *
+ * Captures a Skype auth token from a running Teams session (via CDP Fetch
+ * interception) and makes direct HTTP calls to the Teams Chat Service REST API.
+ *
+ * Flow:
+ *   1. Connect to a Chrome debug session with Teams open
+ *   2. Reload the page to trigger token acquisition
+ *   3. Capture the x-skypetoken from an intercepted request header
+ *   4. Use the token to call {region}.ng.msg.teams.microsoft.com/v1/...
+ *
+ * Key discovery:
+ *   - Teams stores auth tokens encrypted in localStorage; not directly extractable
+ *   - The refresh token is SPA-bound (AADSTS9002327) and cannot be redeemed from Node.js
+ *   - The only reliable extraction path is intercepting live request headers via CDP Fetch
+ *   - The Skype token alone (Authentication: skypetoken=<token>) is sufficient for
+ *     all chat service calls: conversations, messages, members
+ *   - Token lifetime is ~24 hours based on observed expiry timestamps
+ */
+
+import type { Page, CDPSession, Protocol } from "puppeteer-core";
+
+export interface TeamsAuthToken {
+  skypeToken: string;
+  region: string;
+}
+
+export interface TeamsConversation {
+  id: string;
+  topic: string;
+  threadType: string;
+  version: number;
+  lastMessageTime: string | null;
+  memberCount: number | null;
+}
+
+export interface TeamsApiMessage {
+  id: string;
+  messageType: string;
+  from: string;
+  displayName: string;
+  content: string;
+  originalArrivalTime: string;
+  composeTime: string;
+  editTime: string | null;
+  subject: string | null;
+  isDeleted: boolean;
+  emotions: TeamsApiEmotion[];
+  mentions: TeamsApiMention[];
+  quotedMessageId: string | null;
+}
+
+export interface TeamsApiEmotion {
+  key: string;
+  users: Array<{ mri: string; time: number }>;
+}
+
+export interface TeamsApiMention {
+  id: string;
+  displayName: string;
+}
+
+export interface TeamsApiMember {
+  id: string;
+  displayName: string;
+  role: string;
+}
+
+export interface TeamsMessagesPage {
+  messages: TeamsApiMessage[];
+  backwardLink: string | null;
+  syncState: string | null;
+}
+
+const CHAT_SERVICE_BASE = (region: string) =>
+  `https://${region}.ng.msg.teams.microsoft.com/v1`;
+
+const FETCH_INTERCEPT_TIMEOUT = 20_000;
+const PAGE_RELOAD_TIMEOUT = 25_000;
+
+/**
+ * Capture a Skype token from a running Teams page by intercepting
+ * request headers via the CDP Fetch domain during a page reload.
+ */
+export async function captureSkypeToken(
+  teamsPage: Page,
+): Promise<TeamsAuthToken> {
+  const cdpSession: CDPSession = await teamsPage.createCDPSession();
+  let skypeToken: string | null = null;
+
+  await cdpSession.send("Fetch.enable", {
+    patterns: [{ urlPattern: "*teams*", requestStage: "Request" }],
+  });
+
+  const tokenPromise = new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, FETCH_INTERCEPT_TIMEOUT);
+
+    cdpSession.on("Fetch.requestPaused", async (event: Protocol.Fetch.RequestPausedEvent) => {
+      const headers = event.request.headers ?? {};
+      const requestId = event.requestId;
+
+      for (const [name, value] of Object.entries(headers)) {
+        if (name.toLowerCase() === "x-skypetoken" && !skypeToken) {
+          skypeToken = value;
+        }
+      }
+
+      try {
+        await cdpSession.send("Fetch.continueRequest", { requestId });
+      } catch {
+        // Request may have already been handled
+      }
+
+      if (skypeToken) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+  });
+
+  // Reload the page to trigger Teams auth flow
+  teamsPage
+    .reload({ waitUntil: "networkidle2", timeout: PAGE_RELOAD_TIMEOUT })
+    .catch(() => {
+      // Reload may time out, but we should have the token by then
+    });
+
+  await tokenPromise;
+
+  await cdpSession.send("Fetch.disable");
+  await cdpSession.detach();
+
+  if (!skypeToken) {
+    throw new Error(
+      "Failed to capture Skype token. Ensure Teams is loaded and authenticated.",
+    );
+  }
+
+  // Detect region from the Teams page URL or default to apac
+  const region = detectRegion(teamsPage.url());
+
+  return { skypeToken, region };
+}
+
+/**
+ * Find the Teams page in a connected browser.
+ */
+export function findTeamsPage(pages: Page[]): Page | undefined {
+  return pages.find((page) =>
+    /teams\.(microsoft|cloud\.microsoft)/i.test(page.url()),
+  );
+}
+
+/**
+ * Detect the API region from Teams configuration.
+ * Falls back to "apac" if not determinable.
+ */
+function detectRegion(_pageUrl: string): string {
+  // In production, we could detect from apac/emea/amer in API URLs
+  // or from the user's timezone. For now, all regions work identically
+  // (they all return the same data), so we default to apac.
+  return "apac";
+}
+
+function authHeaders(token: TeamsAuthToken): Record<string, string> {
+  return {
+    Authentication: `skypetoken=${token.skypeToken}`,
+  };
+}
+
+/**
+ * Fetch the user's conversation list.
+ */
+export async function fetchConversations(
+  token: TeamsAuthToken,
+  pageSize = 50,
+): Promise<TeamsConversation[]> {
+  const url = `${CHAT_SERVICE_BASE(token.region)}/users/ME/conversations?view=mychats&pageSize=${pageSize}`;
+
+  const response = await fetch(url, { headers: authHeaders(token) });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch conversations: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    conversations: Array<{
+      id: string;
+      version: number;
+      threadProperties?: { topic?: string; threadType?: string; memberCount?: string };
+      properties?: { displayName?: string; lastimreceivedtime?: string };
+    }>;
+  };
+
+  return (data.conversations ?? []).map((conversation) => ({
+    id: conversation.id,
+    topic:
+      conversation.threadProperties?.topic ??
+      conversation.properties?.displayName ??
+      "",
+    threadType: conversation.threadProperties?.threadType ?? "chat",
+    version: conversation.version,
+    lastMessageTime: conversation.properties?.lastimreceivedtime ?? null,
+    memberCount: conversation.threadProperties?.memberCount
+      ? Number(conversation.threadProperties.memberCount)
+      : null,
+  }));
+}
+
+/**
+ * Fetch messages from a specific conversation.
+ * Returns one page of messages plus a backward link for pagination.
+ */
+export async function fetchMessages(
+  token: TeamsAuthToken,
+  conversationId: string,
+  pageSize = 50,
+  backwardLink?: string,
+): Promise<TeamsMessagesPage> {
+  const url =
+    backwardLink ??
+    `${CHAT_SERVICE_BASE(token.region)}/users/ME/conversations/${encodeURIComponent(conversationId)}/messages?pageSize=${pageSize}`;
+
+  const response = await fetch(url, { headers: authHeaders(token) });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch messages: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    messages: Array<Record<string, unknown>>;
+    _metadata?: { backwardLink?: string; syncState?: string };
+  };
+
+  const messages = (data.messages ?? []).map(parseApiMessage);
+
+  return {
+    messages,
+    backwardLink: data._metadata?.backwardLink ?? null,
+    syncState: data._metadata?.syncState ?? null,
+  };
+}
+
+/**
+ * Fetch all messages from a conversation by following pagination links.
+ */
+export async function fetchAllMessages(
+  token: TeamsAuthToken,
+  conversationId: string,
+  options: { maxPages?: number; pageSize?: number; onProgress?: (count: number) => void } = {},
+): Promise<TeamsApiMessage[]> {
+  const maxPages = options.maxPages ?? 100;
+  const pageSize = options.pageSize ?? 200;
+  const allMessages: TeamsApiMessage[] = [];
+  let backwardLink: string | undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const result = await fetchMessages(token, conversationId, pageSize, backwardLink);
+    allMessages.push(...result.messages);
+
+    options.onProgress?.(allMessages.length);
+
+    if (!result.backwardLink) break;
+    backwardLink = result.backwardLink;
+  }
+
+  return allMessages;
+}
+
+/**
+ * Fetch members of a conversation.
+ */
+export async function fetchMembers(
+  token: TeamsAuthToken,
+  conversationId: string,
+): Promise<TeamsApiMember[]> {
+  const url = `${CHAT_SERVICE_BASE(token.region)}/threads/${encodeURIComponent(conversationId)}/members`;
+
+  const response = await fetch(url, { headers: authHeaders(token) });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch members: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    members: Array<{
+      id: string;
+      userDisplayName?: string;
+      role?: string;
+    }>;
+  };
+
+  return (data.members ?? []).map((member) => ({
+    id: member.id,
+    displayName: member.userDisplayName ?? "",
+    role: member.role ?? "member",
+  }));
+}
+
+/**
+ * Parse a raw API message into our structured format.
+ */
+function parseApiMessage(raw: Record<string, unknown>): TeamsApiMessage {
+  const properties = (raw.properties ?? {}) as Record<string, unknown>;
+
+  // Parse emotions from properties
+  const rawEmotions = properties.emotions as
+    | Array<{ key: string; users: Array<{ mri: string; time: number }> }>
+    | string
+    | undefined;
+
+  let emotions: TeamsApiEmotion[] = [];
+  if (typeof rawEmotions === "string") {
+    try {
+      emotions = JSON.parse(rawEmotions) as TeamsApiEmotion[];
+    } catch {
+      emotions = [];
+    }
+  } else if (Array.isArray(rawEmotions)) {
+    emotions = rawEmotions;
+  }
+
+  // Parse mentions
+  const rawMentions = properties.mentions as
+    | Array<{ id: string; displayName?: string }>
+    | string
+    | undefined;
+
+  let mentions: TeamsApiMention[] = [];
+  if (typeof rawMentions === "string") {
+    try {
+      const parsed = JSON.parse(rawMentions) as Array<{ id: string; displayName?: string }>;
+      mentions = parsed.map((mention) => ({
+        id: mention.id ?? "",
+        displayName: mention.displayName ?? "",
+      }));
+    } catch {
+      mentions = [];
+    }
+  } else if (Array.isArray(rawMentions)) {
+    mentions = rawMentions.map((mention) => ({
+      id: mention.id ?? "",
+      displayName: mention.displayName ?? "",
+    }));
+  }
+
+  // Detect quoted messages from content (reply format uses skype schema)
+  let quotedMessageId: string | null = null;
+  const content = String(raw.content ?? "");
+  const quoteMatch = content.match(
+    /itemtype="http:\/\/schema\.skype\.com\/Reply"\s+itemid="(\d+)"/,
+  );
+  if (quoteMatch) {
+    quotedMessageId = quoteMatch[1];
+  }
+
+  return {
+    id: String(raw.id ?? ""),
+    messageType: String(raw.messagetype ?? ""),
+    from: String(raw.from ?? ""),
+    displayName: String(raw.imdisplayname ?? ""),
+    content,
+    originalArrivalTime: String(raw.originalarrivaltime ?? ""),
+    composeTime: String(raw.composetime ?? ""),
+    editTime: raw.properties
+      ? String((properties.edittime as string) ?? "")
+      : null,
+    subject: properties.subject ? String(properties.subject) : null,
+    isDeleted: raw.messagetype === "MessageDelete" || raw.properties
+      ? String(properties.deletetime ?? "") !== ""
+      : false,
+    emotions,
+    mentions,
+    quotedMessageId,
+  };
+}

--- a/src/direct-api-converter.ts
+++ b/src/direct-api-converter.ts
@@ -1,0 +1,248 @@
+/**
+ * Converts Teams direct API response messages into MessageSnapshot objects
+ * compatible with the existing markdown and HTML renderers.
+ */
+
+import type { MessageSnapshot, QuotedReply, ReactionInfo } from "./types.js";
+import type { TeamsApiMessage, TeamsApiMember, TeamsApiEmotion } from "./direct-api-client.js";
+
+/** Map from Teams emotion keys to display emoji + name */
+const EMOTION_MAP: Record<string, { emoji: string; name: string }> = {
+  like: { emoji: "👍", name: "like" },
+  heart: { emoji: "❤️", name: "heart" },
+  laugh: { emoji: "😂", name: "laugh" },
+  surprised: { emoji: "😮", name: "surprised" },
+  sad: { emoji: "😢", name: "sad" },
+  angry: { emoji: "😡", name: "angry" },
+  fistbump: { emoji: "🤜", name: "fist bump" },
+  heartlightblue: { emoji: "💙", name: "blue heart" },
+  yes: { emoji: "✅", name: "yes" },
+  no: { emoji: "❌", name: "no" },
+  clap: { emoji: "👏", name: "clap" },
+  fire: { emoji: "🔥", name: "fire" },
+  mindblown: { emoji: "🤯", name: "mind blown" },
+  party: { emoji: "🎉", name: "party" },
+  eyes: { emoji: "👀", name: "eyes" },
+  pensive: { emoji: "😔", name: "pensive" },
+  rocket: { emoji: "🚀", name: "rocket" },
+  hundred: { emoji: "💯", name: "hundred" },
+  plusone: { emoji: "👍", name: "+1" },
+};
+
+/**
+ * Convert a batch of API messages to MessageSnapshot objects.
+ *
+ * @param apiMessages - Messages from the Teams REST API (should be sorted newest-first from API)
+ * @param members - Optional member list for resolving user IDs to display names
+ * @returns MessageSnapshot[] sorted oldest-first (chronological order for rendering)
+ */
+export function convertApiMessagesToSnapshots(
+  apiMessages: TeamsApiMessage[],
+  members: TeamsApiMember[] = [],
+): MessageSnapshot[] {
+  // Build a member lookup by MRI (e.g., "8:orgid:uuid")
+  const memberLookup = new Map<string, string>();
+  for (const member of members) {
+    memberLookup.set(member.id, member.displayName);
+  }
+
+  // Also build a lookup from message authors
+  for (const message of apiMessages) {
+    if (message.from && message.displayName) {
+      // The 'from' field is a URL like "https://...;messageid=xxx"
+      // The actual MRI is in the URL path. Extract it.
+      const mriMatch = message.from.match(/(8:orgid:[a-f0-9-]+)/);
+      if (mriMatch) {
+        memberLookup.set(mriMatch[1], message.displayName);
+      }
+    }
+  }
+
+  // Build a message lookup for quoted replies
+  const messageLookup = new Map<string, TeamsApiMessage>();
+  for (const message of apiMessages) {
+    messageLookup.set(message.id, message);
+  }
+
+  // Filter to text messages only (skip system events, topic updates, etc.)
+  const textMessages = apiMessages.filter(
+    (message) =>
+      (message.messageType === "RichText/Html" || message.messageType === "Text") &&
+      !message.isDeleted,
+  );
+
+  // Sort chronologically (oldest first) for rendering
+  const sorted = [...textMessages].sort(
+    (first, second) =>
+      new Date(first.originalArrivalTime).getTime() -
+      new Date(second.originalArrivalTime).getTime(),
+  );
+
+  return sorted.map((message, index) =>
+    convertSingleMessage(message, index, memberLookup, messageLookup),
+  );
+}
+
+function convertSingleMessage(
+  message: TeamsApiMessage,
+  index: number,
+  memberLookup: Map<string, string>,
+  messageLookup: Map<string, TeamsApiMessage>,
+): MessageSnapshot {
+  const dateTime = message.originalArrivalTime || message.composeTime;
+  const timeLabel = formatTimeLabel(dateTime);
+
+  // Parse HTML content for plain text
+  const plainText = stripHtml(message.content);
+
+  // Build quoted reply if present
+  const quote = buildQuotedReply(message, messageLookup);
+
+  // Build reactions
+  const reactions = buildReactions(message.emotions, memberLookup);
+
+  // Convert HTML to basic markdown
+  const markdown = htmlToBasicMarkdown(message.content);
+
+  return {
+    id: message.id,
+    index,
+    author: message.displayName || "Unknown",
+    timeLabel,
+    dateTime,
+    subject: message.subject ?? "",
+    quote,
+    reactions,
+    html: message.content,
+    markdown,
+    plainText,
+  };
+}
+
+function formatTimeLabel(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    const day = date.toLocaleDateString("en-GB", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+    const time = date.toLocaleTimeString("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    return `${day}, ${time}`;
+  } catch {
+    return isoString;
+  }
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<blockquote[\s\S]*?<\/blockquote>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function htmlToBasicMarkdown(html: string): string {
+  return html
+    .replace(/<blockquote[\s\S]*?<\/blockquote>/gi, (match) => {
+      const text = stripHtml(match);
+      return text
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    })
+    .replace(/<strong>([\s\S]*?)<\/strong>/gi, "**$1**")
+    .replace(/<em>([\s\S]*?)<\/em>/gi, "*$1*")
+    .replace(/<code>([\s\S]*?)<\/code>/gi, "`$1`")
+    .replace(/<a[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, "[$2]($1)")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>\s*<p>/gi, "\n\n")
+    .replace(/<\/?(p|div|span)[^>]*>/gi, "")
+    .replace(/<img[^>]+alt="([^"]*)"[^>]*>/gi, "[$1]")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+function buildQuotedReply(
+  message: TeamsApiMessage,
+  messageLookup: Map<string, TeamsApiMessage>,
+): QuotedReply | null {
+  if (!message.quotedMessageId) return null;
+
+  // Extract quote info from HTML content
+  const content = message.content;
+  const authorMatch = content.match(
+    /<strong[^>]*itemprop="mri"[^>]*>([\s\S]*?)<\/strong>/i,
+  );
+  const previewMatch = content.match(
+    /<p[^>]*itemprop="preview"[^>]*>([\s\S]*?)<\/p>/i,
+  );
+  const timeMatch = content.match(
+    /<span[^>]*itemprop="time"[^>]*itemid="(\d+)"[^>]*>/i,
+  );
+
+  const author = authorMatch ? stripHtml(authorMatch[1]) : "Unknown";
+  const text = previewMatch ? stripHtml(previewMatch[1]) : "";
+
+  let timeLabel = "";
+  if (timeMatch) {
+    // The itemid is a timestamp
+    const timestamp = Number(timeMatch[1]);
+    if (timestamp > 0) {
+      timeLabel = formatTimeLabel(new Date(timestamp).toISOString());
+    }
+  } else {
+    // Try to get from the quoted message
+    const quotedMessage = messageLookup.get(message.quotedMessageId);
+    if (quotedMessage) {
+      timeLabel = formatTimeLabel(quotedMessage.originalArrivalTime);
+    }
+  }
+
+  return { author, timeLabel, text };
+}
+
+function buildReactions(
+  emotions: TeamsApiEmotion[],
+  memberLookup: Map<string, string>,
+): ReactionInfo[] {
+  if (!emotions || emotions.length === 0) return [];
+
+  return emotions.map((emotion) => {
+    const mapped = EMOTION_MAP[emotion.key] ?? {
+      emoji: "👍",
+      name: emotion.key,
+    };
+
+    const actors = emotion.users.map((user) => {
+      const displayName = memberLookup.get(user.mri);
+      if (displayName) return displayName;
+
+      // Try to extract a readable ID from the MRI
+      const match = user.mri.match(/8:orgid:(.+)/);
+      return match ? match[1].slice(0, 8) : user.mri;
+    });
+
+    return {
+      emoji: mapped.emoji,
+      name: mapped.name,
+      count: emotion.users.length,
+      actors,
+    };
+  });
+}


### PR DESCRIPTION
## Direct API POC

Proof-of-concept: export Teams messages via REST API, bypassing the UI entirely.

Captures skypetoken via CDP Fetch interception, then calls the Teams Chat Service REST API.

Files: direct-api-client.ts, direct-api-converter.ts, export-via-direct-api.mts, validate-direct-api.mts

All 14 validation checks pass. Both markdown and HTML formats working.
