### PR TITLE
feat: Send messages via Teams Direct API

### DIFF
--- a/scripts/send-via-direct-api.mts
+++ b/scripts/send-via-direct-api.mts
@@ -1,0 +1,248 @@
+/**
+ * Send a Teams Message via Direct API
+ *
+ * Acquires an auth token (either via auto-login or connecting to a
+ * running Chrome instance), finds or specifies the target conversation,
+ * and sends a message.
+ *
+ * Usage:
+ *   # Auto-login mode (recommended):
+ *   npx -y tsx scripts/send-via-direct-api.mts --auto --email maxim.mazurok@wisetechglobal.com \
+ *     --to "Maxim Mazurok" --message "Hello from the API!"
+ *
+ *   # Connect to existing Chrome:
+ *   DEBUG_PORT=9223 npx -y tsx scripts/send-via-direct-api.mts \
+ *     --to "Maxim Mazurok" --message "Hello from the API!"
+ *
+ *   # Send to a conversation by topic name:
+ *   npx -y tsx scripts/send-via-direct-api.mts --auto --email maxim.mazurok@wisetechglobal.com \
+ *     --chat "Front End Community" --message "Hello team!"
+ *
+ * Options:
+ *   --to <name|email>          Find 1:1 conversation with this person
+ *   --chat <name>              Find conversation by topic (group chats, channels)
+ *   --message <text>           Message content to send (plain text)
+ *   --auto                     Auto-acquire token (launches fresh Chrome, uses Intune passkey)
+ *   --email <email>            Corporate email for auto login (required with --auto)
+ *   --list                     List conversations and exit
+ */
+
+import puppeteer from "puppeteer-core";
+
+import type { TeamsAuthToken } from "../src/direct-api-client.js";
+import {
+  captureSkypeToken,
+  findTeamsPage,
+  fetchConversations,
+  fetchCurrentUserDisplayName,
+  findOneOnOneConversation,
+  sendMessage,
+} from "../src/direct-api-client.js";
+import { acquireTokenAutomatically } from "../src/auto-token.js";
+
+const browserUrl = `http://127.0.0.1:${Number(process.env.DEBUG_PORT || "9222")}`;
+
+interface CliOptions {
+  recipientFilter: string | null;
+  chatFilter: string | null;
+  messageContent: string | null;
+  listOnly: boolean;
+  autoLogin: boolean;
+  email: string | null;
+}
+
+function parseArguments(): CliOptions {
+  const cliArguments = process.argv.slice(2);
+  const options: CliOptions = {
+    recipientFilter: null,
+    chatFilter: null,
+    messageContent: null,
+    listOnly: false,
+    autoLogin: false,
+    email: null,
+  };
+
+  for (let i = 0; i < cliArguments.length; i++) {
+    switch (cliArguments[i]) {
+      case "--to":
+        options.recipientFilter = cliArguments[++i];
+        break;
+      case "--chat":
+        options.chatFilter = cliArguments[++i];
+        break;
+      case "--message":
+        options.messageContent = cliArguments[++i];
+        break;
+      case "--list":
+        options.listOnly = true;
+        break;
+      case "--auto":
+        options.autoLogin = true;
+        break;
+      case "--email":
+        options.email = cliArguments[++i];
+        break;
+    }
+  }
+
+  return options;
+}
+
+async function acquireToken(
+  options: CliOptions,
+): Promise<{ token: TeamsAuthToken; disconnect: () => void }> {
+  if (options.autoLogin) {
+    if (!options.email) {
+      console.error("--email is required when using --auto");
+      process.exit(1);
+    }
+    console.log("Auto-acquiring token via Intune passkey...");
+    const token = await acquireTokenAutomatically({
+      email: options.email,
+      headless: true,
+      verbose: true,
+    });
+    console.log(
+      `Token captured (${token.skypeToken.length} chars, region: ${token.region})`,
+    );
+    return { token, disconnect: () => {} };
+  }
+
+  console.log(`Connecting to Chrome at ${browserUrl}...`);
+  const browser = await puppeteer.connect({ browserURL: browserUrl });
+
+  const pages = await browser.pages();
+  const teamsPage = findTeamsPage(pages);
+  if (!teamsPage) {
+    console.error(
+      "No Teams page found. Navigate to Teams in the browser first.",
+    );
+    process.exit(1);
+  }
+  console.log(`Teams page: ${teamsPage.url()}`);
+
+  console.log("Capturing auth token...");
+  const token = await captureSkypeToken(teamsPage);
+  console.log(
+    `Token captured (${token.skypeToken.length} chars, region: ${token.region})`,
+  );
+  return { token, disconnect: () => browser.disconnect() };
+}
+
+async function main() {
+  const options = parseArguments();
+
+  const { token, disconnect } = await acquireToken(options);
+
+  try {
+    // List mode
+    if (options.listOnly) {
+      console.log("\nFetching conversations...");
+      const conversations = await fetchConversations(token, 100);
+      const displayableConversations = conversations.filter(
+        (conversation) =>
+          conversation.topic &&
+          ![
+            "streamofannotations",
+            "streamofthreads",
+            "streamofnotifications",
+            "streamofmentions",
+            "streamofnotes",
+          ].includes(conversation.threadType),
+      );
+      console.log(`\n${displayableConversations.length} conversations:\n`);
+      for (let i = 0; i < displayableConversations.length; i++) {
+        const conversation = displayableConversations[i];
+        const lastMessage =
+          conversation.lastMessageTime?.slice(0, 10) ?? "unknown";
+        console.log(
+          `  [${i}] ${conversation.threadType}: "${conversation.topic}" (members: ${conversation.memberCount ?? "?"}, last: ${lastMessage})`,
+        );
+      }
+      return;
+    }
+
+    // Validate required options
+    if (!options.messageContent) {
+      console.error("--message is required. Specify the message text to send.");
+      process.exit(1);
+    }
+
+    if (!options.recipientFilter && !options.chatFilter) {
+      console.error(
+        "Either --to <name> or --chat <name> is required to identify the target conversation.",
+      );
+      process.exit(1);
+    }
+
+    // Find the target conversation
+    let conversationId: string;
+    let conversationLabel: string;
+
+    if (options.recipientFilter) {
+      console.log(
+        `\nSearching for 1:1 conversation with "${options.recipientFilter}"...`,
+      );
+      const result = await findOneOnOneConversation(
+        token,
+        options.recipientFilter,
+      );
+      if (!result) {
+        console.error(
+          `No 1:1 conversation found matching "${options.recipientFilter}".`,
+        );
+        console.log(
+          'Use --list to see available conversations, or use --chat <name> instead.',
+        );
+        process.exit(1);
+      }
+      conversationId = result.conversationId;
+      conversationLabel = result.memberDisplayName;
+      console.log(`  Found: "${conversationLabel}"`);
+    } else {
+      console.log(
+        `\nSearching for conversation matching "${options.chatFilter}"...`,
+      );
+      const conversations = await fetchConversations(token, 100);
+      const filterLower = options.chatFilter!.toLowerCase();
+      const match = conversations.find((conversation) =>
+        conversation.topic?.toLowerCase().includes(filterLower),
+      );
+      if (!match) {
+        console.error(
+          `No conversation matching "${options.chatFilter}" found.`,
+        );
+        console.log("Use --list to see available conversations.");
+        process.exit(1);
+      }
+      conversationId = match.id;
+      conversationLabel = match.topic;
+      console.log(`  Found: "${conversationLabel}"`);
+    }
+
+    // Get sender display name
+    console.log("\nResolving sender identity...");
+    const senderDisplayName = await fetchCurrentUserDisplayName(token);
+    console.log(`  Sending as: "${senderDisplayName}"`);
+
+    // Send the message
+    console.log(`\nSending message to "${conversationLabel}"...`);
+    console.log(`  Content: "${options.messageContent}"`);
+    const messageId = await sendMessage(
+      token,
+      conversationId,
+      options.messageContent,
+      senderDisplayName,
+    );
+    console.log(`\n✅ Message sent successfully!`);
+    console.log(`  Message ID: ${messageId}`);
+    console.log(`  Conversation: ${conversationLabel}`);
+  } finally {
+    disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/src/direct-api-client.ts
+++ b/src/direct-api-client.ts
@@ -372,3 +372,176 @@ function parseApiMessage(raw: Record<string, unknown>): TeamsApiMessage {
     quotedMessageId,
   };
 }
+
+/**
+ * Send a message to a conversation.
+ * Returns the server-assigned message ID.
+ */
+export async function sendMessage(
+  token: TeamsAuthToken,
+  conversationId: string,
+  messageContent: string,
+  senderDisplayName: string,
+): Promise<string> {
+  const url = `${CHAT_SERVICE_BASE(token.region)}/users/ME/conversations/${encodeURIComponent(conversationId)}/messages`;
+
+  const clientMessageId = String(Date.now());
+
+  const body = {
+    content: messageContent,
+    messagetype: "Text",
+    contenttype: "text",
+    clientmessageid: clientMessageId,
+    imdisplayname: senderDisplayName,
+    properties: {
+      importance: "",
+      subject: null,
+    },
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...authHeaders(token),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to send message: ${response.status} ${response.statusText} — ${errorText}`,
+    );
+  }
+
+  const data = (await response.json()) as { OriginalArrivalTime: number; id?: string };
+  return data.id ?? clientMessageId;
+}
+
+/**
+ * Find an existing 1:1 conversation with a specific user by scanning
+ * recent messages for display names.
+ *
+ * The members API doesn't return display names for 1:1 chats, so instead
+ * we fetch a few recent messages from each untitled chat and match against
+ * the sender display names (imdisplayname).
+ *
+ * Also handles the self-chat case (48:notes) when the target matches
+ * the logged-in user.
+ *
+ * Only searches 1:1 chats — use the chatFilter in the CLI script for
+ * matching group chats and meetings by topic.
+ */
+export async function findOneOnOneConversation(
+  token: TeamsAuthToken,
+  targetIdentifier: string,
+): Promise<{ conversationId: string; memberDisplayName: string } | null> {
+  const conversations = await fetchConversations(token, 100);
+
+  const targetLower = targetIdentifier.toLowerCase();
+
+  // Check self-chat first — matches when the user searches for their own name
+  const selfChat = conversations.find((conversation) =>
+    conversation.id.startsWith("48:notes"),
+  );
+  if (selfChat) {
+    const currentUserName = await fetchCurrentUserDisplayName(token);
+    if (currentUserName.toLowerCase().includes(targetLower)) {
+      return { conversationId: selfChat.id, memberDisplayName: `${currentUserName} (self)` };
+    }
+  }
+
+  // Search untitled 1:1 chats by scanning recent messages for sender names
+  const untitledChats = conversations.filter(
+    (conversation) =>
+      conversation.threadType === "chat" && !conversation.topic,
+  );
+
+  for (const chat of untitledChats) {
+    try {
+      const messagesPage = await fetchMessages(token, chat.id, 10);
+      const textMessages = messagesPage.messages.filter(
+        (message) =>
+          message.messageType === "RichText/Html" ||
+          message.messageType === "Text",
+      );
+
+      // Collect unique sender names
+      const senderNames = [
+        ...new Set(
+          textMessages
+            .map((message) => message.displayName)
+            .filter((name) => name.length > 0),
+        ),
+      ];
+
+      // Check if any sender matches the target
+      for (const senderName of senderNames) {
+        if (senderName.toLowerCase().includes(targetLower)) {
+          return { conversationId: chat.id, memberDisplayName: senderName };
+        }
+      }
+    } catch {
+      // Some older chats may not be fetchable
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the display name of the current user from their own message history.
+ *
+ * Fetches recent messages from a conversation and identifies the current
+ * user's display name by finding the most common sender (likely "me").
+ */
+export async function fetchCurrentUserDisplayName(
+  token: TeamsAuthToken,
+): Promise<string> {
+  // The ME/properties endpoint has user settings but not always displayname.
+  // The most reliable approach is to look at our own sent messages.
+  const conversations = await fetchConversations(token, 10);
+
+  for (const conversation of conversations) {
+    try {
+      const messagesPage = await fetchMessages(token, conversation.id, 10);
+      const textMessages = messagesPage.messages.filter(
+        (message) =>
+          (message.messageType === "RichText/Html" ||
+            message.messageType === "Text") &&
+          message.displayName.length > 0,
+      );
+
+      if (textMessages.length === 0) continue;
+
+      // Count sender occurrences — the current user likely appears most often
+      // across multiple conversations. But for a single conversation, just
+      // return the first sender name we find (we'll validate it's "us" later).
+      // For now, use a heuristic: check the self-chat (48:notes) messages
+      if (conversation.id.startsWith("48:notes")) {
+        const selfMessage = textMessages[0];
+        if (selfMessage) return selfMessage.displayName;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // Fallback: try the properties endpoint
+  const url = `${CHAT_SERVICE_BASE(token.region)}/users/ME/properties`;
+  try {
+    const response = await fetch(url, { headers: authHeaders(token) });
+    if (response.ok) {
+      const data = (await response.json()) as Record<string, unknown>;
+      if (typeof data.displayname === "string") {
+        return data.displayname;
+      }
+    }
+  } catch {
+    // Fall through to default
+  }
+
+  return "Unknown User";
+}


### PR DESCRIPTION
## Send Messages POC

Proof of concept for sending messages through the Teams Chat Service REST API.

### New capabilities

- **`sendMessage()`** function in the API client — sends plain text messages to any conversation
- **`findOneOnOneConversation()`** — finds 1:1 chats by scanning recent message sender names (the members API doesn't return display names for 1:1 chats)
- **`fetchCurrentUserDisplayName()`** — resolves the logged-in user's display name from self-chat messages

### CLI Script: `scripts/send-via-direct-api.mts`

```bash
# Send to yourself (self-chat / 48:notes)
npx -y tsx scripts/send-via-direct-api.mts \
  --auto --email maxim.mazurok@wisetechglobal.com \
  --to "Maxim Mazurok" --message "Hello!"

# Send to a group chat by topic
npx -y tsx scripts/send-via-direct-api.mts \
  --auto --email maxim.mazurok@wisetechglobal.com \
  --chat "BW gang" --message "Hello team!"

# List conversations
npx -y tsx scripts/send-via-direct-api.mts \
  --auto --email maxim.mazurok@wisetechglobal.com --list
```

### Options

| Flag | Description |
|------|-------------|
| `--to <name>` | Find 1:1 conversation by scanning recent message senders |
| `--chat <name>` | Find group chat/meeting by topic name |
| `--message <text>` | Plain text message content |
| `--auto` | Auto-acquire token via Intune passkey |
| `--email <email>` | Corporate email for auto login (required with --auto) |
| `--list` | List available conversations and exit |

### Tested scenarios
- Self-chat (48:notes) — `--to "Maxim Mazurok"`
- Group chats — `--chat "BW gang"`
- 1:1 chats — `--to "Luke Prior"` (via message sender scanning)
- Auto-login token acquisition
- Connect-to-existing-Chrome mode

### API details
- **Endpoint**: `POST /v1/users/ME/conversations/{id}/messages`
- **Auth**: `Authentication: skypetoken=<token>`
- **Message type**: `Text` (plain text)
- **Response**: 201 with `OriginalArrivalTime`
